### PR TITLE
fix go mod path issue

### DIFF
--- a/cmd/errchecker/main.go
+++ b/cmd/errchecker/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/harukitosa/merucari/errchecker"
+	"github.com/harukitosa/errchecker"
 	"golang.org/x/tools/go/analysis/unitchecker"
 )
 

--- a/errchecker_test.go
+++ b/errchecker_test.go
@@ -3,7 +3,7 @@ package errchecker_test
 import (
 	"testing"
 
-	"github.com/harukitosa/merucari/errchecker"
+	"github.com/harukitosa/errchecker"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/harukitosa/merucari/errchecker
+module github.com/harukitosa/errchecker
 
 go 1.14
 

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,5 +1,5 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o path_to_plugin_dir github.com/harukitosa/merucari/errchecker/plugin/errchecker
+//    go build -buildmode=plugin -o path_to_plugin_dir github.com/harukitosa/errchecker/plugin/errchecker
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
@@ -7,13 +7,13 @@ package main
 import (
 	"strings"
 
-	"github.com/harukitosa/merucari/errchecker"
+	"github.com/harukitosa/errchecker"
 	"golang.org/x/tools/go/analysis"
 )
 
 // flags for Analyzer.Flag.
 // If you would like to specify flags for your plugin, you can put them via 'ldflags' as below.
-//     $ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" github.com/harukitosa/merucari/errchecker/plugin/errchecker
+//     $ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" github.com/harukitosa/errchecker/plugin/errchecker
 var flags string
 
 // AnalyzerPlugin provides analyzers as a plugin.


### PR DESCRIPTION
go.mod 中のパスと現実のパスが一致していないのを修正

```
$ go build -buildmode=plugin github.com/harukitosa/errchecker/plugin
...
	module declares its path as: github.com/harukitosa/merucari/errchecker
	        but was required as: github.com/harukitosa/errchecker
```

みたいになるのが治るはず…
可能であれば、CIのセットアップを行うと"実は自分の手元でしか動いてない"という問題が早期発見できると思います
